### PR TITLE
moving templates and repo paths to cache-manager

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 **Please check if the PR fulfills these requirements**
-- [ ] Followed the [Contributing](https://github.com/node-cache-manager/node-cache-manager/blob/main/CONTRIBUTING.md) guidelines.
+- [ ] Followed the [Contributing](https://github.com/node-cache-manager/cache-manager/blob/main/CONTRIBUTING.md) guidelines.
 - [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
 - [ ] Docs have been added / updated (for bug fixes / features)
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -242,9 +242,8 @@ When a value will be retrieved from Redis with a TTL minor than 3sec, the value 
 
 ## Contribute
 
-If you would like to contribute to the project, please fork it and send us a pull request. Please add tests
-for any new features or bug fixes.
+If you would like to contribute to the project, please read how to contribute here [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## License
 
-node-cache-manager is licensed under the [MIT license](./LICENSE).
+cache-manager is licensed under the [MIT license](./LICENSE).

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/node-cache-manager/node-cache-manager.git"
+    "url": "https://github.com/node-cache-manager/cache-manager.git"
   },
   "keywords": [
     "cache",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/node-cache-manager/node-cache-manager/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
moving templates and repo paths to cache-manager